### PR TITLE
OAuth2 인가 요청 저장소를 세션 → 쿠키 기반으로 변경

### DIFF
--- a/finpik-api/src/main/java/finpik/auth/security/config/SecurityConfig.java
+++ b/finpik-api/src/main/java/finpik/auth/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package finpik.auth.security.config;
 
 import java.util.List;
 
+import finpik.auth.security.oauth.OAuth2AuthorizationRequestCookieRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,11 +48,17 @@ public class SecurityConfig {
                 .permitAll()
                 .anyRequest()
                 .permitAll()
-            ).oauth2Login(oauth -> oauth.userInfoEndpoint(
-                    user -> user.userService(kakaoOAuth2UserService))
+            ).oauth2Login(oauth -> oauth
+                .userInfoEndpoint(user -> user.userService(kakaoOAuth2UserService))
                 .successHandler(oAuth2SuccessHandler)
-                .failureHandler(oAuth2FailureHandler))
-            .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint));
+                .failureHandler(oAuth2FailureHandler)
+                .authorizationEndpoint(a ->
+                    a.authorizationRequestRepository(new OAuth2AuthorizationRequestCookieRepository())
+                )
+            )
+            .exceptionHandling(exception ->
+                exception.authenticationEntryPoint(authenticationEntryPoint)
+            );
 
         return http.build();
     }

--- a/finpik-api/src/main/java/finpik/auth/security/oauth/OAuth2AuthorizationRequestCookieRepository.java
+++ b/finpik-api/src/main/java/finpik/auth/security/oauth/OAuth2AuthorizationRequestCookieRepository.java
@@ -1,0 +1,73 @@
+package finpik.auth.security.oauth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+public class OAuth2AuthorizationRequestCookieRepository
+    implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    public static final String OAUTH2_AUTH_REQUEST_COOKIE_NAME = "OAUTH2_AUTH_REQ";
+    private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Cookie cookie = getCookie(request, OAUTH2_AUTH_REQUEST_COOKIE_NAME);
+        if (cookie == null) return null;
+        return OAuth2AuthorizationRequestJsonCodec.decode(cookie.getValue());
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request,
+                                         HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
+        String base64 = OAuth2AuthorizationRequestJsonCodec.encode(authorizationRequest);
+        Cookie cookie = new Cookie(OAUTH2_AUTH_REQUEST_COOKIE_NAME, base64);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setMaxAge(COOKIE_EXPIRE_SECONDS);
+        response.addCookie(cookie);
+        addSameSiteNone(response, cookie.getName());
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                 HttpServletResponse response) {
+        OAuth2AuthorizationRequest existing = loadAuthorizationRequest(request);
+
+        Cookie cookie = getCookie(request, OAUTH2_AUTH_REQUEST_COOKIE_NAME);
+        if (cookie != null) {
+            cookie.setValue("");
+            cookie.setPath("/");
+            cookie.setMaxAge(0);
+            cookie.setHttpOnly(true);
+            cookie.setSecure(true);
+            response.addCookie(cookie);
+            addSameSiteNone(response, cookie.getName());
+        }
+        return existing;
+    }
+
+    private static Cookie getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        for (Cookie c : cookies) if (name.equals(c.getName())) return c;
+        return null;
+    }
+
+    private static void addSameSiteNone(HttpServletResponse response, String cookieName) {
+        for (String header : response.getHeaders("Set-Cookie")) {
+            if (header.startsWith(cookieName + "=") && !header.toLowerCase().contains("samesite")) {
+                response.setHeader("Set-Cookie", header + "; SameSite=None; Secure");
+                break;
+            }
+        }
+    }
+}

--- a/finpik-api/src/main/java/finpik/auth/security/oauth/OAuth2AuthorizationRequestJsonCodec.java
+++ b/finpik-api/src/main/java/finpik/auth/security/oauth/OAuth2AuthorizationRequestJsonCodec.java
@@ -1,0 +1,80 @@
+package finpik.auth.security.oauth;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+// TODO(성공시 리팩토링 필요)
+public final class OAuth2AuthorizationRequestJsonCodec {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private OAuth2AuthorizationRequestJsonCodec() {}
+
+    public static String encode(OAuth2AuthorizationRequest req) {
+        try {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("authorizationUri", req.getAuthorizationUri());
+            m.put("clientId", req.getClientId());
+            m.put("redirectUri", req.getRedirectUri());
+            m.put("scopes", new ArrayList<>(req.getScopes()));
+            m.put("state", req.getState());
+            m.put("additionalParameters", filterStringMap(req.getAdditionalParameters()));
+            m.put("attributes", filterStringMap(req.getAttributes()));
+            byte[] json = MAPPER.writeValueAsBytes(m);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(json);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to encode OAuth2AuthorizationRequest", e);
+        }
+    }
+
+    public static OAuth2AuthorizationRequest decode(String base64) {
+        try {
+            byte[] json = Base64.getUrlDecoder().decode(base64);
+            Map<String, Object> m = MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+            String authorizationUri = (String) m.get("authorizationUri");
+            String clientId = (String) m.get("clientId");
+            String redirectUri = (String) m.get("redirectUri");
+            String state = (String) m.get("state");
+
+            @SuppressWarnings("unchecked")
+            List<String> scopesList = (List<String>) m.getOrDefault("scopes", Collections.emptyList());
+            Set<String> scopes = new LinkedHashSet<>(scopesList);
+
+            @SuppressWarnings("unchecked")
+            Map<String, String> additional = (Map<String, String>) m.getOrDefault("additionalParameters", Collections.emptyMap());
+            @SuppressWarnings("unchecked")
+            Map<String, String> attrs = (Map<String, String>) m.getOrDefault("attributes", Collections.emptyMap());
+
+            OAuth2AuthorizationRequest.Builder b = OAuth2AuthorizationRequest.authorizationCode()
+                .authorizationUri(authorizationUri)
+                .clientId(clientId)
+                .redirectUri(redirectUri)
+                .scopes(scopes)
+                .state(state)
+                .additionalParameters(new LinkedHashMap<>(additional));
+            b.attributes(a -> a.putAll(attrs));
+
+            return b.build();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to decode OAuth2AuthorizationRequest", e);
+        }
+    }
+
+    private static Map<String, String> filterStringMap(Map<String, Object> in) {
+        if (in == null) return Collections.emptyMap();
+        Map<String, String> out = new LinkedHashMap<>();
+        in.forEach((k, v) -> {
+            if (v != null) out.put(k, String.valueOf(v));
+        });
+        return out;
+    }
+}


### PR DESCRIPTION
- Custom AuthorizationRequestRepository 구현 추가
- OAuth2AuthorizationRequest를 HttpOnly, Secure, SameSite=None 쿠키에 저장/복원
- 세션 미사용(stateless) 환경에서 발생하던 `authorization_request_not_found` 오류 해결
- 카카오 OAuth2 로그인 플로우가 HTTPS/크로스 도메인 환경에서도 정상 동작하도록 개선