### PR TITLE
쿠키 domain 설정에서 https://를 붙인 잘못된 url 사용 수정

### DIFF
--- a/finpik-api/src/main/java/finpik/auth/security/handler/OAuth2SuccessHandler.java
+++ b/finpik-api/src/main/java/finpik/auth/security/handler/OAuth2SuccessHandler.java
@@ -40,8 +40,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     @Value("${fin-pik.redirect.redirect_uri}")
     private String redirectUri;
-    @Value("${fin-pik.domain.domain_url}")
-    private String domainUrl;
     @Value("${cookie.secure}")
     private boolean cookieSecure;
     @Value("${cookie.same-site:Lax}")
@@ -110,7 +108,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private void setRefreshTokenOnCookie(HttpServletResponse response, String refreshToken) {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN, refreshToken)
-            .domain(domainUrl)
             .httpOnly(true)
             .secure(cookieSecure)
             .path("/")


### PR DESCRIPTION
기존에 ResponseCookie domain에 "https://finpik.o-r.kr"을 넣어 IllegalArgumentException이 발생함.
도메인에는 host만 설정하거나 생략하도록 수정하여 쿠키가 정상 동작하도록 함.
현재는 httpOnly 가 true이기에 현재 도메인에만 사용되어 domain 지우기 가능